### PR TITLE
Add linux support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,25 @@
 
-JAVAC=javac
-JAVA_HOME=$(shell /usr/libexec/java_home)
+JAVAC := javac
+CFLAGS :=
 
-all: dist/rubicon.jar dist/librubicon.dylib dist/test.jar
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+
+ifeq ($(uname_S),Linux)
+	JAVA_HOME:=$(shell sh -c 'dirname $$(dirname $$(readlink -e $$(which $(JAVAC))))')
+	JAVA_PLATFORM := $(JAVA_HOME)/include/linux
+	CFLAGS := -fPIC
+	CFLAGS += -DLIBPYTHON_RTLD_GLOBAL=1
+	SOEXT := so
+	PYLDFLAGS :=  $(shell sh -c 'python-config --ldflags')
+endif
+ifeq ($(uname_S),Darwin)
+	JAVA_HOME := $(shell /usr/libexec/java_home)
+	JAVA_PLATFORM := $(JAVA_HOME)/include/darwin
+	SOEXT := dylib
+	PYLDFLAGS := -lPython
+endif
+
+all: dist/rubicon.jar dist/librubicon.$(SOEXT) dist/test.jar
 
 dist/rubicon.jar: org/pybee/rubicon/Python.class org/pybee/rubicon/PythonInstance.class
 	mkdir -p dist
@@ -12,9 +29,9 @@ dist/test.jar: org/pybee/rubicon/test/BaseExample.class org/pybee/rubicon/test/E
 	mkdir -p dist
 	jar -cvf dist/test.jar org/pybee/rubicon/test/*.class
 
-dist/librubicon.dylib: jni/rubicon.o
+dist/librubicon.$(SOEXT): jni/rubicon.o
 	mkdir -p dist
-	gcc -shared -lPython -o $@ $<
+	gcc -shared -o $@ $< $(PYLDFLAGS)
 
 test: all
 	java org.pybee.rubicon.test.Test
@@ -29,5 +46,5 @@ clean:
 	$(JAVAC) $<
 
 %.o : %.c
-	gcc -c -Isrc -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin -o $@ $<
+	gcc -c $(CFLAGS) -Isrc -I$(JAVA_HOME)/include -I$(JAVA_PLATFORM) -o $@ $<
 

--- a/jni/rubicon.c
+++ b/jni/rubicon.c
@@ -1,5 +1,8 @@
 #include <jni.h>
 #include <stdio.h>
+#ifdef LIBPYTHON_RTLD_GLOBAL
+#include <dlfcn.h>
+#endif
 
 #include "python2.7/Python.h"
 
@@ -812,6 +815,11 @@ JNIEXPORT jint JNICALL Java_org_pybee_rubicon_Python_start(JNIEnv *env, jobject 
 
     LOG_I("Start Python runtime...");
     java = env;
+
+#ifdef LIBPYTHON_RTLD_GLOBAL
+    // make libpython symbols availiable for everyone
+    dlopen("libpython2.7.so", RTLD_LAZY|RTLD_GLOBAL|RTLD_NOLOAD);
+#endif
 
     // Special environment to prefer .pyo, and don't write bytecode if .py are found
     // because the process will not have write attribute on the device.


### PR DESCRIPTION
This commit change Makefile to support both OSX and Linux.

Use `make` to build.

Then you can test library with
`
LD_LIBRARY_PATH=dist RUBICON_LIBRARY=dist/librubicon.so make test
`
